### PR TITLE
Sets required providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ No modules.
 |------|------|
 | [helm_release.cert-manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.plugins](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [rad-security_cluster_api_key.this](https://registry.terraform.io/providers/hashicorp/rad-security/latest/docs/resources/cluster_api_key) | resource |
+| [rad-security_cluster_api_key.this](https://registry.terraform.io/providers/rad-security/rad-security/latest/docs/resources/cluster_api_key) | resource |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_providers {
+    rad-security = {
+      source = "rad-security/rad-security"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+}
+
 resource "rad-security_cluster_api_key" "this" {}
 
 resource "helm_release" "cert-manager" {


### PR DESCRIPTION
The required_providers was not set properly in the module. This PR fixes it.

old:
```
Providers required by configuration:
.
├── provider[registry.terraform.io/rad-security/rad-security] 1.1.3
└── module.rad-security-plugins
    ├── provider[registry.terraform.io/hashicorp/rad-security]
    └── provider[registry.terraform.io/hashicorp/helm]
```

new:
```
terraform providers

Providers required by configuration:
.
├── provider[registry.terraform.io/hashicorp/helm] 2.15.0
├── provider[registry.terraform.io/rad-security/rad-security] 1.1.3
└── module.rad-security-plugins
    ├── provider[registry.terraform.io/rad-security/rad-security]
    └── provider[registry.terraform.io/hashicorp/helm]
```