### PR TITLE
Fixes typos in Terraform output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "rad_plugin_namespace" {
-  value = helm_release.rad_plugin.namespace
+  value = helm_release.plugins.namespace
 }
 
 output "sbom_service_account_name" {


### PR DESCRIPTION
The output should use the proper name of the Helm Release for the Rad Plugins. It is no longer called `rad_plugin`.